### PR TITLE
List requirements before linting and testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ yeehaw = [
 dependencies = [
   "black>=24.8.0",
   "mypy>=1.0.0",
-  "pytest==8.2.2",  # Using an older version until https://github.com/pytest-dev/pytest/issues/12355 is patched to 8.3
+  "pytest<8",  # Collection of parameterized tests hangs in version 8.x.x
   "requests>=2.32.3",
   "ruff>=0.5.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ path = "src/ninja_taisen/__about__.py"
 
 [tool.hatch.envs.default.scripts]
 lint = [
+  "pip list",
   "ruff check",
   "mypy --install-types --non-interactive ."
 ]
@@ -35,7 +36,10 @@ format = [
   "black **/*.py",
   "ruff check --fix --unsafe-fixes"
 ]
-test = "pytest {args: tests}"
+test = [
+  "pip list",
+  "pytest {args: tests}"
+]
 regen = "pytest tests/regression --regen"
 check = [
   "hatch run format",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ yeehaw = [
 dependencies = [
   "black>=24.8.0",
   "mypy>=1.0.0",
-  "pytest>=8.3.2",
+  "pytest==8.2.2",  # Using an older version until https://github.com/pytest-dev/pytest/issues/12355 is patched to 8.3
   "requests>=2.32.3",
   "ruff>=0.5.6",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import logging
 
 import pytest
-from _pytest.config import Parser
+from _pytest.config.argparsing import Parser
 from _pytest.fixtures import FixtureRequest
 from _pytest.logging import LogCaptureFixture
 


### PR DESCRIPTION
On GitHubActions certain parameterized tests are hanging on test collection.

I believe this is due to https://github.com/pytest-dev/pytest/issues/12355 - it looks to be patched to 8.2.2, but I'm not certain that it's on 8.3.2, so let's try an earlier version.